### PR TITLE
rework !color-block

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -33,7 +33,7 @@
   return: "The basic outline of an image is printed using a key block. These blocks are typically printed using a black pigment."
   limit: 10
 "!color-block":
-  return: "Color blocks are used to print a single color. If an image has 6 colors then 6 unique color blocks must be carved."
+  return: "Color blocks are used to add color to a print. Each block can add one or more colors with each impression. Color blocks that overlap can layer pigments so that there are more colors in the final print than the number of blocks used."
   limit: 10
 "!sizing":
   return: "Before the paper is prepared for printing it must be sized. A coat is added to the top side to allow the pigments to stick to the paper uniformly. Another is added to the back to protect the surface and facilitate the rubbing by the baren. Read more about this here: http://woodblock.com/encyclopedia/entries/016_02/016_02.html"


### PR DESCRIPTION
It has been mentioned a few times in chat recently that the current !color-block command is not technically correct. It is sometimes possible to use one side of a block with different parts being different colors. It's also been mentioned that layering colors can bring out more colors in the final print than the number of blocks used.